### PR TITLE
add splitter utility

### DIFF
--- a/NPIF Splitter.py
+++ b/NPIF Splitter.py
@@ -1,0 +1,75 @@
+#-------------------------------------------------------------------------
+# Name:         NPIF Splitter
+# Purpose:      split a 7023 file into multiple files (one per table)
+#
+# Based on NPIF Sleuth, by sfhelsdon-dstl
+#
+############################################################################
+#
+# Intellectual Property Rights
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2018 Dstl
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+#
+#-------------------------------------------------------------------------
+
+from NPIF import *
+from S7023_GUI import *
+
+
+def NPIF_Split(fname):
+    retstring = None
+    # Create Tablelist Object
+    a = Tablelist()
+    #
+    # check file looks 7023 like and can be opened
+    if a.Check_Is_7023_File(fname) is False:
+        retstring = "Do not recognise:\n" + str(fname) + "\nas a valid 7023 file"
+        return retstring
+    #
+    # get filename with no extension on the end
+    noext = os.path.splitext(fname)[0]
+    #
+    # read in the file
+    a.Open_7023_File(fname)
+    tableIndex = 0
+    for p in a.packets:
+        tablefile = open(noext + "_table_" + str(tableIndex).zfill(4) + ".7023", 'wb')
+        tablefile.write(NPIF.SYNC_FIELD)
+        tablefile.write(p.hdr.serialise())
+        tablefile.write(p.tdat.dataraw)
+        tablefile.close()
+        tableIndex += 1
+    #
+    return retstring
+
+
+def main():
+    fname = Get7023_Filename()
+    # check this looks like a 7023 file
+    retval = NPIF_Split(fname)
+    if retval is not None:
+        Do7023_ErrorBox(retval)
+    # all done
+
+if __name__ == '__main__':
+    main()

--- a/NPIF.py
+++ b/NPIF.py
@@ -330,6 +330,62 @@ class NPIF_Header():
             # set to true to indicate no data packet extraction
         self.tablename = None        # text
 
+    """
+    Serialise the header values to a byte array.
+    """
+    def serialise(self):
+        f = struct.pack('>4B3IQB5s2s',
+        self.edition,
+        self._build_flags(),
+        self.segmentnum,
+        self.sourceaddress,
+        self.datafileaddress,
+        self.datafilesize,
+        self.datafilenum,
+        self.timetag,
+        self.Lookup_Sync_Type_Text(self.synctype),
+        binascii.unhexlify(self.reserved),
+        binascii.unhexlify(self.headcrc)
+        )
+        return f
+
+    def Lookup_Sync_Type_Text(self, text):
+        """
+        Return an integer enumeration corresponding to the given String.
+
+        Given a string describing the Sync type from a packet header return an int
+        derived from the STANAG 7023 enumeration for Sync code.
+
+        """
+        if text == "INACTIVE":
+            return 0
+        elif text == "SUPER FRAME SYNC":
+            return 1
+        elif text == "FRAME SYNC":
+            return 2
+        elif text == "FIELD SYNC":
+            return 4
+        elif text == "SWATH SYNC":
+            return 8
+        elif text == "LINE SYNC":
+            return 10
+        elif text == "TILE SYNC":
+            return 12
+        else:
+            raise ValueError("Invalid text value for sync code lookup: " + text)
+
+    def _build_flags(self):
+        """
+        Get the header flags as an encoded value
+        """
+        intflags = 0
+        if self.ambleflag:
+            intflags = intflags | 8
+        if self.crcflag:
+            intflags = intflags | 4
+        if self.compressflag:
+            intflags = intflags | 2
+        return intflags
 
 class NPIF_DataContent():
     """

--- a/README.md
+++ b/README.md
@@ -14,3 +14,9 @@ The tool is not sufficient to certify a file as being compliant with the standar
 outputs should be carefully reviewed by someone familiar with the NPIF standard.
 
 Please note the Licence conditions (see LICENSE.txt)
+
+## NPIF Splitter
+
+This is a support application to split a STANAG 7023 file into parts (one file per table).
+This is probably not of general interest, but may be useful for debugging or generating
+test cases.


### PR DESCRIPTION
This PR proposed a utility (heavily based on NPIF Sleuth.py that breaks up a NPIF file into component files.
I needed something like that to help generate more test cases for my implementation, and offer it for consideration.